### PR TITLE
MaxScaleDenominator errors

### DIFF
--- a/GML stylesheets/GeoServer stylesheets (SLD)/Backdrop style/VML-backdrop-RoadCLine.sld
+++ b/GML stylesheets/GeoServer stylesheets (SLD)/Backdrop style/VML-backdrop-RoadCLine.sld
@@ -2746,7 +2746,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
 		</ogc:Or>
           </ogc:Filter>
           <MinScaleDenominator>7000</MinScaleDenominator>
-          <MaxScaleDenominator>1500</MaxScaleDenominator>
+          <MaxScaleDenominator>15000</MaxScaleDenominator>
           <TextSymbolizer 		uom="http://www.opengeospatial.org/se/units/metre">
             <Label>
               <ogc:Function name="strConcat">

--- a/GML stylesheets/GeoServer stylesheets (SLD)/Full Colour style/VML-fullcolour-RoadCLine.sld
+++ b/GML stylesheets/GeoServer stylesheets (SLD)/Full Colour style/VML-fullcolour-RoadCLine.sld
@@ -2746,7 +2746,7 @@ xsi:schemaLocation="http://www.opengis.net/sld http://schemas.opengis.net/sld/1.
 		</ogc:Or>
           </ogc:Filter>
           <MinScaleDenominator>7000</MinScaleDenominator>
-          <MaxScaleDenominator>1500</MaxScaleDenominator>
+          <MaxScaleDenominator>15000</MaxScaleDenominator>
           <TextSymbolizer 		uom="http://www.opengeospatial.org/se/units/metre">
             <Label>
               <ogc:Function name="strConcat">


### PR DESCRIPTION
Both RoadCLine GML SLDs have a typo in the MaxScaleThreshold for the `<!-- Road Names 1:7000 - 1:15000 -->` rule.

They have:

`<MaxScaleDenominator>1500</MaxScaleDenominator>`

where this is intended:

`<MaxScaleDenominator>15000</MaxScaleDenominator>`

